### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
-FROM debian:bullseye
+FROM debian:bullseye AS build
 
 RUN apt-get update
 RUN apt-get --no-install-recommends -y install build-essential libasound2-dev libpulse-dev libgtk2.0-dev unzip autoconf automake git
 
+COPY . /dectalk
+
 WORKDIR /dectalk/src
 
-CMD autoreconf -i && ./configure && make
+RUN ./autogen.sh
+RUN ./configure
+RUN make -j
+
+FROM scratch AS output-only
+
+COPY --from=build /dectalk/dist ./dist
+

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ The built files will be found in the `/dist` folder.
 <summary>Compiling on Linux with Docker</summary>
 
 To build DECtalk without setting up a local build environment, run `sudo docker-compose up`
-(and make sure you have Docker and docker-compose installed!)
+(and make sure you have Docker and docker-compose installed!). The `dist` directory should appear in the project root with the build output.
+
+If you want to build with only Docker, you can run `sudo docker build --output=. .` to build and output the `dist` directory to the project root. If you run into permission errors, try making a new directory with full write access and output to it, e.g. `mkdir output`, `chmod 777 ./output`, `sudo docker build --output=./output .`.
 
 </details>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
-version: '3.6'
 services:
   dectalk:
-    build: .
+    build:
+      context: .
+      target: build
     volumes:
-      - ./:/dectalk
-      
+      - ./dist:/dist
+    command: ["cp", "-r", "/dectalk/dist/.", "/dist"]


### PR DESCRIPTION
Fixes Docker build primarily by changing the Dockerfile to run the correct commands, but also by refactoring dectalk's whole build to occur during the image build step rather than when the container is running. Due to this, the docker-compose now just copies the dist directory to a volume and immediately exits since the binaries are already built.

Additionally, thanks to a new build stage at the end of the Dockerfile, you can also just build the project with `sudo docker build --output=./output .`, which will then copy all of the files from the last build stage (which is just the dist directory and its contents) into an output directory.

Fixes #56 
Fixes #72 