### PR TITLE
Various fixes to restore a more classic DECtalk sound

### DIFF
--- a/src/dapi/src/ph/ph_defs.h
+++ b/src/dapi/src/ph/ph_defs.h
@@ -802,7 +802,7 @@ handled differently later */
 #define   F0_FINAL_FALL 180
 #define   F0_NON_FINAL_FALL  80
 #define	  F0_QSYLL_FALL	80
-#define   F0_GLOTTALIZE  -100
+#define   F0_GLOTTALIZE  -131 // was -100
 #define Reduce_last 50
 
 #endif
@@ -811,7 +811,7 @@ handled differently later */
 
 
 #define   F0_CBOUND_PULSE   700
-#define   F0_GLOTTALIZE    -60 //New method that drops per cycle rather than impulse BATS 796 EAB 11/4/98
+#define   F0_GLOTTALIZE    -100 // was -60
 #define SCHWA1 LAP_IX
 #define SCHWA2 LAP_IX
 #define F0_QGesture1 -150
@@ -849,7 +849,7 @@ handled differently later */
 
 
 #define   F0_CBOUND_PULSE   700
-#define   F0_GLOTTALIZE     -60 //New method that drops per cycle rather than impulse BATS 796 EAB 11/4/98
+#define   F0_GLOTTALIZE     -100 // was -60
 #define SCHWA1 SPP_IX
 #define SCHWA2 SPP_IX
 #define F0_QGesture1 -150
@@ -885,7 +885,7 @@ handled differently later */
 #define   F0_NON_FINAL_FALL  	150
 #define	  F0_COMMA_FALL		120
 #define	  F0_QSYLL_FALL		80
-#define   F0_GLOTTALIZE    -60 //New method that drops per cycle rather than impulse BATS 796 EAB 11/4/98
+#define   F0_GLOTTALIZE    -131 // was -60
 #define   Reduce_last 50
 
 #endif

--- a/src/dapi/src/ph/ph_inton1.c
+++ b/src/dapi/src/ph/ph_inton1.c
@@ -1814,7 +1814,7 @@ duplication is so that the rules fire in the correct order also*/
 							/* EAB with addition of new code to glotalize in phdrwt0 this
 							needs to grt alot weaker*/
 #ifdef GERMAN
-							pDph_t->test_targf0 = targf0>>2;	/* RSM */
+							pDph_t->test_targf0 = targf0;	/* full glottalization target (was targf0>>2) */
 							pDph_t->impulse_width = 10;			/* RSM */
 							if(pDph_t->number_words == 1)
 							{
@@ -1827,7 +1827,7 @@ duplication is so that the rules fire in the correct order also*/
 				the phoneme following the syllable nucleus is voiced BATS 796. */
 							if(phone_feature( pDph_t,phonex) & FVOICD)
 							{
-								pDph_t->test_targf0 = targf0>>3;
+								pDph_t->test_targf0 = targf0;	/* full glottalization target (was targf0>>3) */
 								if(nphon+2 <= pDph_t->nallotot && (phone_feature( pDph_t,pDph_t->allophons[nphon+2]) & FVOICD))
 									/* nucleus has two voiced phonemes following it so delay even more*/
 								{
@@ -1926,7 +1926,7 @@ duplication is so that the rules fire in the correct order also*/
 					/* eab 4/13/98 comment is wrong this is stressed vowel so review code in detail 
 					when time permits*/
 #ifdef GERMAN
-					pDph_t->test_targf0 = targf0>>2;
+					pDph_t->test_targf0 = targf0;	/* full glottalization target (was targf0>>2) */
 					pDph_t->impulse_width = 10;
 					if(pDph_t->number_words == 1)
 					{
@@ -1938,7 +1938,7 @@ duplication is so that the rules fire in the correct order also*/
 					the phoneme following the syllable nucleus is voiced.BATS 796  */
 					if(phone_feature( pDph_t,phonex) & FVOICD)
 					{
-						pDph_t->test_targf0 = targf0>>3;
+						pDph_t->test_targf0 = targf0;	/* full glottalization target (was targf0>>3) */
 						if(nphon+2 <= pDph_t->nallotot && (phone_feature( pDph_t,pDph_t->allophons[nphon+2]) & FVOICD))
 							/* nucleus has two voiced phonemes following it so delay even more*/
 						{

--- a/src/dapi/src/ph/ph_setar.c
+++ b/src/dapi/src/ph/ph_setar.c
@@ -1452,9 +1452,11 @@ static void make_dip (PDPH_T pDph_t,
 		if ((struccur & FSTRESS) IS_MINUS)
 		{
 			/* Increased coarticulation, especially F2, if unstressed */
-			   pDphsettar->gencoartic = N15PRCNT; 
+			/* OUT  -- 4.60 keeps this disabled so gencoartic stays N10PRCNT:
+			   pDphsettar->gencoartic = N15PRCNT;
 			   if (pDphsettar->np == &PF2)
 			   { pDphsettar->gencoartic = N25PRCNT; }
+			   END OUT */
 		}
 		pDph_t->arg1 = pDphsettar->np->tarlas - oldvalue;
 		pDph_t->arg2 = pDphsettar->gencoartic;
@@ -1525,22 +1527,22 @@ static void make_dip (PDPH_T pDph_t,
 				}
 				/* Special rule: (see subroutine) */
 				//newvalue += special_coartic (pDph_t, pDph_t->nphone, ++dip_pos);
-				tmp = pDph_t->nphone & PFONT;
+				tmp = get_phone(pDph_t, pDph_t->nphone) & PFONT;
 			if(tmp == PFUSA<<PSFONT)
 			{
-				newvalue += us_special_coartic (pDph_t, pDph_t->nphone, 0);
+				newvalue += us_special_coartic (pDph_t, pDph_t->nphone, ++dip_pos);
 			}
 			else if(tmp == PFGR<<PSFONT)
 			{	
-				newvalue += gr_special_coartic (pDph_t, pDph_t->nphone, 0);
+				newvalue += gr_special_coartic (pDph_t, pDph_t->nphone, ++dip_pos);
 			}
 			else if(tmp == PFLA<<PSFONT)
 			{
-				newvalue += la_special_coartic (pDph_t, pDph_t->nphone, 0);
+				newvalue += la_special_coartic (pDph_t, pDph_t->nphone, ++dip_pos);
 			}
 			else if(tmp == PFSP<<PSFONT)
 			{
-				newvalue += sp_special_coartic (pDph_t, pDph_t->nphone, 0);
+				newvalue += sp_special_coartic (pDph_t, pDph_t->nphone, ++dip_pos);
 			}
 			else if(tmp == PFFR<<PSFONT)
 			{

--- a/src/dapi/src/ph/ph_sort2.c
+++ b/src/dapi/src/ph/ph_sort2.c
@@ -147,7 +147,7 @@ if(pKsd_t->lang_curr != LANG_german)
 	/* Else try to find a vowel to stress in last word */
 	for (m = *locend - 1; m >= nstartphrase; m--)
 	{
-		if (pDph_t->symbols[m] >= WBOUND)
+		if (((pDph_t->symbols[m] & PVALUE) >= WBOUND) && ((pDph_t->symbols[m] & PVALUE) <= EXCLAIM))
 		{
 
 			locbeg = m;

--- a/src/dapi/src/ph/ph_task.c
+++ b/src/dapi/src/ph/ph_task.c
@@ -678,7 +678,7 @@ void ph_loop(LPTTS_HANDLE_T phTTS,unsigned short *input)
 				/* GL 10/03/1996, use period to end the control phones */
 				/* GL 11/13/1997  set to comma for NWSNOAA */
 
-				pDph_t->symbols[pDph_t->nsymbtot] = PERIOD;
+				pDph_t->symbols[pDph_t->nsymbtot] = COMMA;	/* PATCH: restore v4.3 comma pause on inline command (PERIOD since GL 10/03/1996) */
 				pDph_t->user_durs[pDph_t->nsymbtot] = 0;
 				pDph_t->user_f0[pDph_t->nsymbtot++] = 0;
 				speak_now (phTTS);

--- a/src/dapi/src/vtm/vtm1.c
+++ b/src/dapi/src/vtm/vtm1.c
@@ -420,7 +420,8 @@ overhead fixing it here is just as functional as in PH but a lot safer and easie
   {
   case SAMPLE_RATE_INCREASE:
 
-    T0inS4 = frac1mul( pVtm_t->rate_scale, T0inS4 ) << 1;
+    /* round full-res Q14 to keep singing in tune and preserve vibrato at high notes */
+    T0inS4 = (S16)(((S32)pVtm_t->rate_scale * (S32)T0inS4 + 8192) >> 14);
     break;
 
   case SAMPLE_RATE_DECREASE:


### PR DESCRIPTION
This PR contains some changes to DECtalk 4.99 that, when applied, make it sound closer to classic DECtalk versions like 4.3 and 4.4. It also contains a fix for a bug present in all classic DECtalk Software versions, actually making it sound closer to DECtalk PC and Express hardware. Most of these are verified directly against DECtalk 4.3 and 4.4, and in part, DECtalk 4.6 source code. Everything has been built and tested on Windows with Visual Studio 6, though mostly US and UK English. I can provide audio samples to demonstrate if desired.

1) The files ph_inton1.c and ph_defs.h have been changed to fix the sentence-final pitch fall, as can otherwise be controlled inline with the [:dv as x] command. This has been verified against disassembly of DECtalk 4.3 and 4.4. It effectively makes the pitch go a bit lower at the end of the sentence, just like in classic DECtalk versions. As an example, when entering the text "DECtalk Express is running.", "ning" will be about a note lower in pitch, about the same as DECtalk 4.4.
Note: Originally in 4.3 and 4.4, as could only go up to 100, but I've left the maximum at 200 to provide more range, though the default value for each voice should now sound right.

2) ph_setar has been changed to let phonemes progress more or less in the same way as in classic DECtalk versions, most noticeably when singing. As an example, when using the phoneme "ey<800,25>", it would progress slowly from "e" to "y" over the duration, whereas now it's much more stable. This was verified against 4.6 source code.

3) ph_sort2.c has been changed to fix a few things.
a) In specific singing cases, the last note sung would be about 4 dB louder in volume than the rest, as in the following example: "[:phone on][laa<300,13>laa<300,17>laa<300,20>laa<300,25>laa<300,20>laa<300,17>laa<900,13>]" This has now been fixed.
b) DECtalk will now rise in pitch when it encounters a comma, colon or the like, just before it pauses, as is also the case with classic DECtalk versions.
c) If a sentence contains an exclamation point, DECtalk would mostly only raise the pitch near the end, whereas it now might raise the pitch at the start and then go down, just like classic versions. This specific change has also been tested with German, where it appears to also have a positive effect, e.g. when entering "Heute!", the emphasis is now put on the first rather than the second syllable, which I believe is correct.

4) This last change does not so much bring DECtalk closer to the 4.3 and 4.4 sound as to the DECtalk PC and Express sound. This fixes a bug caused by incorrect pitch period scaling from the original 10 kHz (like the hardware) to 11.025 kHz, which caused higher singing notes to be out of tune and have less vibrato. Basically, the higher up you went, the more out of tune and the less vibrato the notes would have. This has now been fixed to sound more like the hardware, making singing (especially to music) much more pleasant.

To be absolutely clear, these changes were made with heavy help from AI, but as said, I've built and tested everything, and haven't found any problems. Everything I've tried sounds right to me, though feel free to correct me if something is off. I've made each point as a separate commit, so you can leave some out if necessary.