### PR TITLE
Fix Win64 callback pointer truncation

### DIFF
--- a/src/dapi/src/api/tts.h
+++ b/src/dapi/src/api/tts.h
@@ -85,6 +85,17 @@
 
 #include "port.h"
 
+#ifndef TTS_POINTER_TYPES_DEFINED
+#define TTS_POINTER_TYPES_DEFINED
+#if defined(_WIN64)
+typedef LONG_PTR TTS_CALLBACK_PARAM_T;
+typedef ULONG_PTR TTS_INSTANCE_PARAM_T;
+#else
+typedef LONG TTS_CALLBACK_PARAM_T;
+typedef DWORD TTS_INSTANCE_PARAM_T;
+#endif
+#endif
+
 #if defined __linux__  || defined VXWORKS || defined _SPARC_SOLARIS_ || defined __EMSCRIPTEN__ || defined (__APPLE__)
 #define HWND unsigned long
 #include "dtmmedefs.h"
@@ -345,10 +356,10 @@ struct TTS_HANDLE_TAG
   void (*main_lts_loop)(void *,unsigned short *);     
 #endif
 #else
-  void (*DtCallbackRoutine)(LONG,LONG,DWORD,UINT);     //New Audio Integration :After testing remove these comments
+  void (*DtCallbackRoutine)(TTS_CALLBACK_PARAM_T,TTS_CALLBACK_PARAM_T,TTS_INSTANCE_PARAM_T,UINT);     //New Audio Integration :After testing remove these comments
 #endif
 
-  DWORD dwTTSInstanceParameter;    //New Audio Integration
+  TTS_INSTANCE_PARAM_T dwTTSInstanceParameter;    //New Audio Integration
 #ifdef WIN32
   HMUTEX_T hmxCallback;            //New Audio Integration
   LPCRITICAL_SECTION pcsMemoryBuffer;
@@ -509,12 +520,12 @@ void TextToSpeechErrorHandler( LPTTS_HANDLE_T,
 LPTTS_HANDLE_T TextToSpeechGetHandle(void);
 */
 #ifdef WIN32
-void Report_TTS_Status( LPTTS_HANDLE_T ttsHandle, UINT uiMsg, long lParam1, long lParam2);
+void Report_TTS_Status( LPTTS_HANDLE_T ttsHandle, UINT uiMsg, TTS_CALLBACK_PARAM_T lParam1, TTS_CALLBACK_PARAM_T lParam2);
 #endif
 
 /* GL 04/21/1997  add this as the latest OSF code */
 #if defined __linux__ || defined VXWORKS || defined _SPARC_SOLARIS_ || defined __osf__ || defined __EMSCRIPTEN__ || defined (__APPLE__)
-void Report_TTS_Status( LPTTS_HANDLE_T phTTS, UINT uiMsg, long lParam1, long lParam2);
+void Report_TTS_Status( LPTTS_HANDLE_T phTTS, UINT uiMsg, TTS_CALLBACK_PARAM_T lParam1, TTS_CALLBACK_PARAM_T lParam2);
 #endif
 
 void QueueToMemory( LPTTS_HANDLE_T, LPSAMPLE_T, DWORD );

--- a/src/dapi/src/api/ttsapi.c
+++ b/src/dapi/src/api/ttsapi.c
@@ -658,9 +658,9 @@ unsigned int PlayAudioCallbackRoutine( HPLAY_AUDIO_T pPlayAudio,
 									  ATYPE_T aInstance,
 									  ATYPE_T aMessage,
 									  ATYPE_T aItem_1 );
-VOID DefaultTTSCallbackRoutine(LONG lParam1,
-							   LONG lParam2,
-							   DWORD dwInstanceParam,
+VOID DefaultTTSCallbackRoutine(TTS_CALLBACK_PARAM_T lParam1,
+							   TTS_CALLBACK_PARAM_T lParam2,
+							   TTS_INSTANCE_PARAM_T dwInstanceParam,
 							   UINT uiMsg);
 
 //#ifdef WIN32
@@ -1822,8 +1822,8 @@ void ReleaseLicenseRef(int *a32_lic)
 MMRESULT TextToSpeechStartupEx( LPTTS_HANDLE_T * pphTTS,
 							   UINT uiDeviceNumber,
 							   DWORD dwDeviceOptions,
-							   VOID (*DtCallbackRoutine)(LONG,LONG,DWORD,UINT),
-							   LONG dwTTSInstanceParameter)
+							   VOID (*DtCallbackRoutine)(TTS_CALLBACK_PARAM_T,TTS_CALLBACK_PARAM_T,TTS_INSTANCE_PARAM_T,UINT),
+							   TTS_INSTANCE_PARAM_T dwTTSInstanceParameter)
 {
 
 
@@ -1921,8 +1921,8 @@ return TextToSpeechStartupExFonix( pphTTS,
 MMRESULT TextToSpeechStartupExFonix( LPTTS_HANDLE_T * pphTTS,
 							   UINT uiDeviceNumber,
 							   DWORD dwDeviceOptions,
-							   VOID (*DtCallbackRoutine)(LONG,LONG,DWORD,UINT),
-							   LONG dwTTSInstanceParameter,
+							   VOID (*DtCallbackRoutine)(TTS_CALLBACK_PARAM_T,TTS_CALLBACK_PARAM_T,TTS_INSTANCE_PARAM_T,UINT),
+							   TTS_INSTANCE_PARAM_T dwTTSInstanceParameter,
 #ifdef WIN32
 							   TCHAR *dictionary_file_name)
 #else
@@ -3449,8 +3449,8 @@ phTTS->uiID_Start_Message =
 MMRESULT TextToSpeechStartup( LPTTS_HANDLE_T * pphTTS,
 							 UINT uiDeviceNumber,
 							 DWORD dwDeviceOptions,
-							 VOID (*DtCallbackRoutine)(LONG,LONG,DWORD,UINT),
-							 LONG dwTTSInstanceParameter)
+							 VOID (*DtCallbackRoutine)(TTS_CALLBACK_PARAM_T,TTS_CALLBACK_PARAM_T,TTS_INSTANCE_PARAM_T,UINT),
+							 TTS_INSTANCE_PARAM_T dwTTSInstanceParameter)
 {
 	
 	
@@ -3473,7 +3473,7 @@ MMRESULT TextToSpeechStartup( HWND hWnd,
 		uiDeviceNumber,
 		dwDeviceOptions|TTSSTARTUP_USING_DEFAULT_CALLBACK,
 		DefaultTTSCallbackRoutine,
-		(LONG)hWnd));
+		(TTS_INSTANCE_PARAM_T)hWnd));
 
 /* GL 11/19/1998, the following codes never get used */
 
@@ -3524,9 +3524,9 @@ MMRESULT TextToSpeechStartup( HWND hWnd,
 }
 
 
-VOID DefaultTTSCallbackRoutine(LONG lParam1,
-							   LONG lParam2,
-							   DWORD dwInstanceParam,
+VOID DefaultTTSCallbackRoutine(TTS_CALLBACK_PARAM_T lParam1,
+							   TTS_CALLBACK_PARAM_T lParam2,
+							   TTS_INSTANCE_PARAM_T dwInstanceParam,
 							   UINT uiMsg)
 {
 #ifdef API_DEBUG
@@ -10798,8 +10798,8 @@ unsigned int PlayAudioCallbackRoutine( HPLAY_AUDIO_T pPlayAudio,
 #ifdef WIN32
 void Report_TTS_Status( LPTTS_HANDLE_T ttsHandle,
 					   UINT uiMsg,
-					   long lParam1,
-					   long lParam2 )
+					   TTS_CALLBACK_PARAM_T lParam1,
+					   TTS_CALLBACK_PARAM_T lParam2 )
 {
 	if (lParam1 == TTS_AUDIO_PLAY_START)	ttsHandle->IsSpeaking = TRUE;	// KSB - Used for start of speech
 	if (lParam1 == TTS_AUDIO_PLAY_STOP)	ttsHandle->IsSpeaking = FALSE;	// KSB - Used for end of speech
@@ -10828,8 +10828,8 @@ void Report_TTS_Status( LPTTS_HANDLE_T ttsHandle,
 #if defined __osf__ || defined __linux__ || defined VXWORKS || defined _SPARC_SOLARIS_ || defined __EMSCRIPTEN__ || defined (__APPLE__)
 void Report_TTS_Status( LPTTS_HANDLE_T phTTS,
 					   UINT uiMsg,
-					   long lParam1,
-					   long lParam2 )
+					   TTS_CALLBACK_PARAM_T lParam1,
+					   TTS_CALLBACK_PARAM_T lParam2 )
 {
 	if (phTTS->DtCallbackRoutine != NULL && uiMsg != 0xDEADC0DE)
 	{

--- a/src/dapi/src/api/ttsapi.h
+++ b/src/dapi/src/api/ttsapi.h
@@ -157,6 +157,17 @@ extern "C" {
 #include "dtmmedefs.h"
 #endif
 
+#ifndef TTS_POINTER_TYPES_DEFINED
+#define TTS_POINTER_TYPES_DEFINED
+#if defined(_WIN64)
+typedef LONG_PTR TTS_CALLBACK_PARAM_T;
+typedef ULONG_PTR TTS_INSTANCE_PARAM_T;
+#else
+typedef LONG TTS_CALLBACK_PARAM_T;
+typedef DWORD TTS_INSTANCE_PARAM_T;
+#endif
+#endif
+
 /* GL 04/21/1997  add this as the latest OSF code */
 /* I don't think we use this yet */
 #ifndef BLD_DECTALK_DLL
@@ -541,20 +552,20 @@ typedef void * LPTTS_HANDLE_T;
 MMRESULT TextToSpeechStartupEx( LPTTS_HANDLE_T * pphTTS,
 				UINT ,
 				DWORD ,
-				VOID (*DtCallbackRoutine)(LONG,
-							  LONG,
-							  DWORD,
+				VOID (*DtCallbackRoutine)(TTS_CALLBACK_PARAM_T,
+							  TTS_CALLBACK_PARAM_T,
+							  TTS_INSTANCE_PARAM_T,
 							  UINT),
-				LONG );
+				TTS_INSTANCE_PARAM_T );
 
 MMRESULT TextToSpeechStartupExFonix( LPTTS_HANDLE_T * pphTTS,
 				UINT ,
 				DWORD ,
-				VOID (*DtCallbackRoutine)(LONG,
-							  LONG,
-							  DWORD,
+				VOID (*DtCallbackRoutine)(TTS_CALLBACK_PARAM_T,
+							  TTS_CALLBACK_PARAM_T,
+							  TTS_INSTANCE_PARAM_T,
 							  UINT),
-				LONG,
+				TTS_INSTANCE_PARAM_T,
 #ifdef WIN32
 				TCHAR *
 #else
@@ -566,11 +577,11 @@ MMRESULT TextToSpeechStartupExFonix( LPTTS_HANDLE_T * pphTTS,
 MMRESULT TextToSpeechStartup( LPTTS_HANDLE_T * pphTTS,
 			      UINT ,
 			      DWORD ,
-			      VOID (*DtCallbackRoutine)(LONG,
-							LONG,
-							DWORD,
+			      VOID (*DtCallbackRoutine)(TTS_CALLBACK_PARAM_T,
+							TTS_CALLBACK_PARAM_T,
+							TTS_INSTANCE_PARAM_T,
 							UINT),
-			      LONG );
+			      TTS_INSTANCE_PARAM_T );
 #endif
 
 #ifdef WIN32


### PR DESCRIPTION
## Summary

- preserve DECtalk's historical 32-bit callback ABI on existing platforms
- use pointer-sized callback and instance parameters on Win64
- prevent buffer pointers, window handles, and callback context values from being truncated in AMD64 builds

## Why

The callback's second parameter carries pointer values for events such as in-memory audio buffers, and the instance parameter can carry a window handle or caller context. `LONG` and `DWORD` remain 32-bit on Win64, so storing these values in those types truncates the upper half of a 64-bit address. This breaks 64-bit consumers, including modern NVDA speech-driver integrations.

The new aliases resolve to `LONG_PTR` and `ULONG_PTR` only under `_WIN64`. On other targets they retain the existing `LONG` and `DWORD` types, avoiding an ABI change for 32-bit and non-Windows builds.

## Testing

- Built the full Visual Studio 2022 solution in `Release - ENGLISH_US|AMD64`
- Result: 0 errors
- The equivalent pointer-sized change has also been used successfully by an x64 NVDA DECtalk driver
