### PR TITLE
Update Docker build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye AS build
+FROM debian:bookworm AS build
 
 RUN apt-get update
 RUN apt-get --no-install-recommends -y install build-essential libasound2-dev libpulse-dev libgtk2.0-dev unzip autoconf automake git


### PR DESCRIPTION
Debian Bullseye reached its [end of life on 2026-08-31](https://www.debian.org/News/2026/20260831), and as a result, the Docker version of the build fails when running the `apt` update and installation steps. This change upgrades the base build image to Bookworm, which will have support until 2028-06-30.

I tested by successfully building with `mkdir output; docker build --output=./output .` on an Ubuntu Server 24.04 box and in WSL (Ubuntu 22.04) in a Windows 11 machine.